### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,38 +127,37 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+      <% if @items != nil %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <% @items.each do |item| %>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <%# <div class='sold-out'> %>
+              <%# <span>Sold Out!!</span> %>
+            <%# </div> %>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.delivery_fee %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
+          <% end %>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +175,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -120,6 +120,7 @@
   </div>
   <%# /FURIMAの特徴 %>
 
+
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,9 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-      
       <% if @items != nil %>
-      <li class='list'>
-        <% @items.each do |item| %>
+      <% @items.each do |item| %>
+        <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
@@ -155,8 +154,8 @@
             </div>
           </div>
           <% end %>
-        <% end %>
-      </li>
+        </li>
+      <% end %>  
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-      <% if @items != nil %>
+      <% if @items.count != 0 %>
       <% @items.each do |item| %>
         <li class='list'>
           <%= link_to "#" do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -147,7 +147,7 @@
               <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br><%= item.delivery_fee %></span>
+              <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>


### PR DESCRIPTION
# What
　商品一覧表示機能の実装

# Why
　フリマアプリの商品一覧を表示できるようにするため。

確認動画
・データがない場合はダミー画像を表示する
　https://gyazo.com/80d689baeaa42024d81ff9e6426add2a
・データがある場合は商品の一覧が表示される
　https://gyazo.com/6a5ec624cb0912be036f6c1915b2eb5d